### PR TITLE
Make sure we're not stuck in an infinite loop of merging the same data into itself

### DIFF
--- a/lib/combine_pdf/parser.rb
+++ b/lib/combine_pdf/parser.rb
@@ -748,7 +748,7 @@ module CombinePDF
     # this method reviews a Hash an updates it by merging Hash data,
     # preffering the new over the old.
     HASH_UPDATE_PROC_FOR_NEW = Proc.new do |_key, old_data, new_data|
-      if old_data.is_a? Hash
+      if old_data.is_a? Hash && old_data != new_data
         old_data.merge(new_data, &HASH_UPDATE_PROC_FOR_NEW)
       else
         new_data


### PR DESCRIPTION
Still need to investigate what would lead to `old_data` being the same as `new_data`, but this is leading to a stack overflow in certain cases where the PDF is poorly formatted (possibly due to overlapping text)